### PR TITLE
Exporting the plain KeyEvent class as well

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,6 +1,6 @@
 import { DeviceEventEmitter } from 'react-native';
 
-class KeyEvent {
+export class KeyEvent {
   onKeyDownListener(cb) {
     this.removeKeyDownListener();
     this.listenerKeyDown = DeviceEventEmitter.addListener('onKeyDown', cb);


### PR DESCRIPTION
I have the need to listen to key events in multiple places of my project. I want to make sure to clean up the listeners when I don't need them any longer, but not clean up listeners that have been registered in other components.

I am using your lib like this now:

```js
import { KeyEvent as RNKeyEvent } from "react-native-keyevent";

class MyComponent extends React.PureComponent<Props> {
  keyEventListener: RNKeyEvent;

  componentDidMount() {
    this.keyEventListener = new RNKeyEvent();

    this.keyEventListener.onKeyDownListener((keyEvent: KeyEvent) => {
      //...
    });

  componentWillUnmount() {
    this.keyEventListener.removeKeyDownListener();
  }

  // ...
}
```